### PR TITLE
[add] #109 チャット画面にメニュー追加

### DIFF
--- a/lib/colors.dart
+++ b/lib/colors.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
-  static const Color mainColor = Color(0xFF554488);
-  static const Color subColor = Color(0xFF61CAE8);
-  static const Color accentColor = Color(0xFFE71B16);
-  static const Color background = Color(0xFFD9D9D9);
-  static const Color background_a = Color(0xFFEAEFF8);
-  static const Color background_b = Color(0xFF61CAE8);
-  static const Color white = Color(0xFFF8F6FF); // 白色
-  static const Color black = Color(0xFF201A33); // 黒色
+  static const Color mainColor = Color(0xff554488);
+  static const Color subColor = Color(0xff5eddff);
+  static const Color accentColor = Color(0xfffbff82);
+  static const Color background = Color(0xFFc5d0d6); // ダイアログ等背景
+  static const Color background_a = Color(0xFFa59fce); // advanced背景
+  static const Color background_b = Color(0xFFfffde1); // basic背景
+  static const Color white = Color(0xFFeaeff8); // 白色
+  static const Color black = Color(0xFF20394f); // 黒色
 }

--- a/lib/ui_chat.dart
+++ b/lib/ui_chat.dart
@@ -31,6 +31,8 @@ class _ChatPageState extends State<ChatPage> {
   bool isFirstSend = false; // はじめの問題文の送信をしたか
   bool _isSending = false; // 二度目以降、問題文の送信中を判断
 
+  bool openMenu = false; // メニュー管理
+
   List<String> labels = []; // ラベルの格納用リスト
 
   // テキストのコントローラー
@@ -96,9 +98,8 @@ class _ChatPageState extends State<ChatPage> {
       final response = await AI.sendMessage(
           Content.text(userMessage)); // AIにメッセージを送信
       String aiMessage = response.text ?? 'イオからのメッセージが取得できませんでした'; // AIの返答を取得
-
       setState(() {
-        chats.add(chat(1, aiMessage)); // AIの返答を会話リストに追加
+        chats.add(chat(1, aiMessage.trimRight())); // AIの返答を会話リストに追加
         _isSending = false;
       });
 
@@ -151,7 +152,7 @@ class _ChatPageState extends State<ChatPage> {
           // アバター表示
           Positioned(
             top: MediaQuery.of(context).size.height * 0.18,
-            left: MediaQuery.of(context).size.width * -0.1,
+            left: MediaQuery.of(context).size.width * -0.05,
             child: SizedBox(
               height: MediaQuery.of(context).size.height * 0.26,
               width: MediaQuery.of(context).size.width * 0.7,
@@ -184,31 +185,42 @@ class _ChatPageState extends State<ChatPage> {
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
                     ),
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: AppColors.white, width: 2),
+                    borderRadius: BorderRadius.circular(40),
+                    border: Border.all(color: AppColors.background, width: 3),
                   ),
                   child: Text('イオ', style: TextStyle(
-                    color: AppColors.white,
-                    shadows: [
-                      Shadow(
-                        blurRadius: 20,
-                        color: AppColors.black,
-                        offset: Offset(0, 0),
-                      ),
-                    ],
+                    color: AppColors.black,
                     fontSize: 20,
                     fontWeight: FontWeight.bold,),)
+              )
+          ),
+
+          // メニュー⇆チャット切替ボタン
+          Positioned(
+              top: MediaQuery.of(context).size.height * 0.15,
+              right: MediaQuery.of(context).size.width * 0.15,
+              child:
+              MenuButton(
+                icon: openMenu ? Icons.chat : Icons.menu,
+                onPressed: () {
+                  setState(() {
+                    openMenu = !openMenu;
+                  });
+                  },
               )
           ),
 
           // 会話部分
           Column(
             children: [
-              SizedBox(height: MediaQuery.of(context).size.height * 0.05,),
+              SizedBox(
+                height: MediaQuery.of(context).size.height * 0.05,
+                width: MediaQuery.of(context).size.width,
+              ),
 
               // 問題文を表示するボタン
               Container(
-                width: MediaQuery.of(context).size.width * 0.95,
+                width: MediaQuery.of(context).size.width * 0.9,
                 height: MediaQuery.of(context).size.height * 0.1,
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
@@ -217,7 +229,7 @@ class _ChatPageState extends State<ChatPage> {
                     end: Alignment.bottomRight,
                   ),
                   borderRadius: BorderRadius.circular(40),
-                  border: Border.all(color: AppColors.white, width: 4),
+                  border: Border.all(color: AppColors.background, width: 3),
                   boxShadow: [
                     BoxShadow(
                       color: AppColors.mainColor.withOpacity(0.7),
@@ -245,10 +257,10 @@ class _ChatPageState extends State<ChatPage> {
                                 end: Alignment.bottomRight,
                               ),
                               borderRadius: BorderRadius.circular(12),
-                              border: Border.all(color: AppColors.white, width: 4),
+                              border: Border.all(color: AppColors.background, width: 4),
                             ),
                           child: Padding(
-                            padding: const EdgeInsets.all(16.0),
+                            padding: const EdgeInsets.all(8),
                             child: Column(
                               mainAxisSize: MainAxisSize.max,
                               children: [
@@ -286,32 +298,26 @@ class _ChatPageState extends State<ChatPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(50),
                     ),
-                    padding: EdgeInsets.symmetric(horizontal: 48, vertical: 24),
+                    padding: EdgeInsets.symmetric(vertical: 12, horizontal: 24),
                   ),
                   child: Text(
                     inputText,
                     style: TextStyle(
-                      color: AppColors.white,
-                      shadows: [
-                        Shadow(
-                          blurRadius: 20,
-                          color: AppColors.black,
-                          offset: Offset(0, 0),
-                        ),
-                      ],
+                      color: AppColors.black,
                       fontSize: MediaQuery.of(context).size.width * 0.05,
                       fontWeight: FontWeight.bold,
                     ),
                     overflow: TextOverflow.ellipsis,
-                    maxLines: 1,
+                    maxLines: 2,
                   ),
                 ),
               ),
 
-              SizedBox(height: MediaQuery.of(context).size.height * 0.22),
+              SizedBox(height: MediaQuery.of(context).size.height * 0.25),
 
               // チャット部分
-              Expanded(
+              if (!openMenu)
+                Expanded(
                 child: ListView.builder(
                   reverse: true,
                   padding: EdgeInsets.all(16),
@@ -335,15 +341,16 @@ class _ChatPageState extends State<ChatPage> {
                                 ),
                                 child: IntrinsicWidth(
                                   child: Container(
-                                    padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                                    padding: EdgeInsets.symmetric(vertical: 8, horizontal: 24),
                                     margin: EdgeInsets.only(bottom: 8, left: chat.p == 0 ? 40 : 8, right: chat.p == 0 ? 8 : 40),
+                                    constraints: BoxConstraints(minWidth: 80),
                                     decoration: BoxDecoration(
                                       gradient: LinearGradient(
                                         colors: [chat.p == 0 ? AppColors.mainColor : AppColors.subColor, chat.p == 0 ? AppColors.mainColor : AppColors.white],
                                         begin: Alignment.topLeft,
                                         end: Alignment.bottomRight,
                                       ),
-                                      borderRadius: BorderRadius.circular(12),
+                                      borderRadius: BorderRadius.circular(24),
                                     ),
                                     child: Text(
                                       chat.str,
@@ -370,7 +377,147 @@ class _ChatPageState extends State<ChatPage> {
                 ),
               ),
 
+              // メニュー部分
+              if (openMenu)
+                Expanded(
+                    child: Column(
+                      children: [
+                        SizedBox(height: MediaQuery.of(context).size.height * 0.1,),
+
+                        // ヘルプボタン
+                        Container(
+                          width: MediaQuery.of(context).size.width * 0.8,
+                          height: MediaQuery.of(context).size.height * 0.05,
+                          decoration: BoxDecoration(
+                            color: AppColors.mainColor,
+                            borderRadius: BorderRadius.circular(24),
+                            border: Border.all(color: AppColors.background, width: 3),
+                            boxShadow: [
+                              BoxShadow(
+                                color: AppColors.mainColor.withOpacity(0.7),
+                                offset: Offset(0, 4),
+                                blurRadius: 10,
+                              ),
+                            ],
+                          ),
+                          child: ElevatedButton(
+                            onPressed: () {},
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.transparent,
+                              shadowColor: Colors.transparent,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                            ),
+                            child: Text(
+                              'チャット画面の使い方',
+                              style: TextStyle(
+                                color: AppColors.white,
+                                fontSize: MediaQuery.of(context).size.width * 0.05,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+
+                        SizedBox(height: MediaQuery.of(context).size.height * 0.05,),
+
+                        // ホームに戻るボタン
+                        Container(
+                          width: MediaQuery.of(context).size.width * 0.8,
+                          height: MediaQuery.of(context).size.height * 0.05,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [AppColors.subColor, AppColors.white],
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                            ),
+                            borderRadius: BorderRadius.circular(24),
+                            border: Border.all(color: AppColors.background, width: 3),
+                            boxShadow: [
+                              BoxShadow(
+                                color: AppColors.mainColor.withOpacity(0.7),
+                                offset: Offset(0, 4),
+                                blurRadius: 10,
+                              ),
+                            ],
+                          ),
+                          child: ElevatedButton(
+                            onPressed: () {Navigator.pushNamed(context, '/home');},
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.transparent,
+                              shadowColor: Colors.transparent,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                            ),
+                            child: Text(
+                              'ホームに戻る',
+                              style: TextStyle(
+                                color: AppColors.black,
+                                fontSize: MediaQuery.of(context).size.width * 0.05,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+
+                        SizedBox(height: MediaQuery.of(context).size.height * 0.05,),
+
+                        // 今の問題をやり直すボタン
+                        Container(
+                          width: MediaQuery.of(context).size.width * 0.8,
+                          height: MediaQuery.of(context).size.height * 0.05,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [AppColors.subColor, AppColors.white],
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                            ),
+                            borderRadius: BorderRadius.circular(24),
+                            border: Border.all(color: AppColors.background, width: 3),
+                            boxShadow: [
+                              BoxShadow(
+                                color: AppColors.mainColor.withOpacity(0.7),
+                                offset: Offset(0, 4),
+                                blurRadius: 10,
+                              ),
+                            ],
+                          ),
+                          child: ElevatedButton(
+                            onPressed: () {
+                              setState(() {
+                                chats.clear();
+                                chats.add(chat(0, inputText));
+                                openMenu = false;
+                              });
+                              AI.sendMessage(Content.text('もう一度始めから教えて！'));
+                              _getAIResponse(inputText);
+
+                            },
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.transparent,
+                              shadowColor: Colors.transparent,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                            ),
+                            child: Text(
+                              '始めからやり直す',
+                              style: TextStyle(
+                                color: AppColors.black,
+                                fontSize: MediaQuery.of(context).size.width * 0.05,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    )
+                ),
+
               // 入力部分
+              if (!openMenu)
               Padding(
                 padding: const EdgeInsets.all(20),
                 child: Row(
@@ -383,11 +530,18 @@ class _ChatPageState extends State<ChatPage> {
                         decoration: InputDecoration(
                           hintText: _isSending ? "イオの応答を待っています..." : "メッセージを入力...",
                           hintStyle: TextStyle(color: AppColors.mainColor),
-                          border: OutlineInputBorder(
+                          enabledBorder: OutlineInputBorder( // 未フォーカス時
                             borderRadius: BorderRadius.circular(12),
                             borderSide: BorderSide(
-                              color: AppColors.mainColor,
-                              width: 2, // 枠線の太さ
+                              color: _isSending ? AppColors.background : AppColors.mainColor,
+                              width: 3,
+                            ),
+                          ),
+                          focusedBorder: OutlineInputBorder( // フォーカス時
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide(
+                              color: _isSending ? AppColors.background : AppColors.mainColor,
+                              width: 4,
                             ),
                           ),
                         ),
@@ -396,7 +550,7 @@ class _ChatPageState extends State<ChatPage> {
                     SizedBox(width: 8),
                     FloatingActionButton(
                       onPressed: _isSending ? null : _sendMessage,
-                      child: Icon(Icons.send, color: AppColors.white),
+                      child: Icon(Icons.send, color: _isSending ? AppColors.black : AppColors.background),
                       backgroundColor: _isSending ? AppColors.background : AppColors.mainColor,
                     ),
                   ],
@@ -407,74 +561,40 @@ class _ChatPageState extends State<ChatPage> {
             ],
           ),
 
-          // ボタングループ
+          // チャット終了ボタン
           Positioned(
-            top: MediaQuery.of(context).size.height * 0.2,
+            top: MediaQuery.of(context).size.height * 0.32,
             left: MediaQuery.of(context).size.width * 0.5,
-            child: Container(
-                width: MediaQuery.of(context).size.width * 0.4,
-              child: Column(
-                children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      // ホームボタン
-                      CircleIconButton(
-                        icon: Icons.home,
-                        onPressed: () {
-                          Navigator.pushNamed(context, '/home');
-                        },
-                      ),
-
-                      SizedBox(height: MediaQuery.of(context).size.width * 0.1),
-
-                      // やり直しボタン
-                      CircleIconButton(
-                        icon: Icons.change_circle_outlined,
-                        onPressed: () {
-                          setState(() {
-                            chats.clear();
-                            chats.add(chat(0, inputText));
-                          });
-                          AI.sendMessage(Content.text('もう一度始めから教えて！'));
-                          _getAIResponse(inputText);
-                        },
-                      ),
-                    ],
+            child:
+            Container(
+              width: MediaQuery.of(context).size.width * 0.4,
+              height: MediaQuery.of(context).size.height * 0.06,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [AppColors.accentColor, AppColors.white],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+                borderRadius: BorderRadius.circular(40),
+                border: Border.all(color: AppColors.background, width: 3),
+                boxShadow: [
+                  BoxShadow(
+                    color: AppColors.accentColor.withOpacity(0.7),
+                    offset: Offset(0, 4),
+                    blurRadius: 10,
                   ),
+                ],
+              ),
+              child: ElevatedButton(
+                onPressed: () async { //フィードバックへ遷移
+                  try {
+                    final feedback = await AI.sendMessage(Content.text(//簡単なフィードバック
+                        '今回の会話はどうだった？私が苦手なところとか分かったら短く(50文字程度)一文で教えてほしいな．'));
+                    final feedbackMessage = feedback.text ??
+                        'フィードバックの作成に失敗しました';
 
-                  SizedBox(height: MediaQuery.of(context).size.height * 0.02),
-
-                  // チャット終了ボタン
-                  Container(
-                    width: MediaQuery.of(context).size.width * 0.4,
-                    height: MediaQuery.of(context).size.height * 0.06,
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        colors: [AppColors.accentColor, AppColors.white],
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                      ),
-                      borderRadius: BorderRadius.circular(40),
-                      border: Border.all(color: AppColors.white, width: 4),
-                      boxShadow: [
-                        BoxShadow(
-                          color: AppColors.accentColor.withOpacity(0.7),
-                          offset: Offset(0, 4),
-                          blurRadius: 10,
-                        ),
-                      ],
-                    ),
-                    child: ElevatedButton(
-                      onPressed: () async { //フィードバックへ遷移
-                        try {
-                          final feedback = await AI.sendMessage(Content.text(//簡単なフィードバック
-                              '今回の会話はどうだった？私が苦手なところとか分かったら短く(50文字程度)一文で教えてほしいな．'));
-                          final feedbackMessage = feedback.text ??
-                              'フィードバックの作成に失敗しました';
-                          
-                          //詳細のフィードバックを作成
-                          final info = await AI.sendMessage(Content.text('''
+                    //詳細のフィードバックを作成
+                    final info = await AI.sendMessage(Content.text('''
                           今回の会話について，
                           1,どういう解き方を最初したのか
                           2,ユーザーが間違えてた部分
@@ -483,70 +603,60 @@ class _ChatPageState extends State<ChatPage> {
                           を，必ず以下のフォーマットで送ってください
                           &&内容1&&内容2&&内容3&&内容4
                           '''));
-                          String infotext = info.text ?? '作成失敗';
-                          final B = infotext.substring(infotext.indexOf('&&')).split('&&');
-                          String firstans = B[1];     //どういう解き方を最初したのか
-                          String wrong = B[2];        //間違えてた部分
-                          String wrongpartans = B[3]; //間違えてた部分の正しい解き方
-                          String correctans = B[4];   //それの正しい解き方
-                          // print("sdoifsdjffd");
-                          // print(firstans);
-                          // print(wrong);
-                          // print(wrongpartans);
-                          // print(correctans);
+                    String infotext = info.text ?? '作成失敗';
+                    final B = infotext.substring(infotext.indexOf('&&')).split('&&');
+                    String firstans = B[1];     //どういう解き方を最初したのか
+                    String wrong = B[2];        //間違えてた部分
+                    String wrongpartans = B[3]; //間違えてた部分の正しい解き方
+                    String correctans = B[4];   //それの正しい解き方
+                    // print("sdoifsdjffd");
+                    // print(firstans);
+                    // print(wrong);
+                    // print(wrongpartans);
+                    // print(correctans);
 
-                          Navigator.pushNamed(
-                            context, '/result',
-                            arguments: {
-                              'inputText': inputText,
-                              'feedbackText': feedbackMessage,
-                              'labels': labels,
-                              'firstans': firstans,
-                              'wrong': wrong,
-                              'wrongpartans': wrongpartans,
-                              'correctans': correctans,
-                            },
-                          );
-                        } catch (e) {
-                          Navigator.pushNamed(
-                            context, '/result',
-                            arguments: {
-                              'inputText': inputText,
-                              'feedbackText': 'フィードバックの作成に失敗しました',
-                              'labels': labels,
-                            },
-                          );
-                        }
-
+                    Navigator.pushNamed(
+                      context, '/result',
+                      arguments: {
+                        'inputText': inputText,
+                        'feedbackText': feedbackMessage,
+                        'labels': labels,
+                        'firstans': firstans,
+                        'wrong': wrong,
+                        'wrongpartans': wrongpartans,
+                        'correctans': correctans,
                       },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.transparent,
-                        shadowColor: Colors.transparent,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(30),
-                        ),
-                      ),
-                      child: Text(
-                        '解けた！',
-                        style: TextStyle(
-                          color: AppColors.white,
-                          shadows: [
-                            Shadow(
-                              blurRadius: 20,
-                              color: AppColors.black,
-                              offset: Offset(0, 0),
-                            ),
-                          ],
-                          fontSize: MediaQuery.of(context).size.width * 0.05,
-                          fontWeight: FontWeight.bold,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                      ),
-                    ),
+                    );
+                  } catch (e) {
+                    Navigator.pushNamed(
+                      context, '/result',
+                      arguments: {
+                        'inputText': inputText,
+                        'feedbackText': 'フィードバックの作成に失敗しました',
+                        'labels': labels,
+                      },
+                    );
+                  }
+
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.transparent,
+                  shadowColor: Colors.transparent,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
                   ),
-                ],
-              )
+                ),
+                child: Text(
+                  '振り返りへ',
+                  style: TextStyle(
+                    color: AppColors.black,
+                    fontSize: MediaQuery.of(context).size.width * 0.05,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
             ),
           ),
 
@@ -556,14 +666,14 @@ class _ChatPageState extends State<ChatPage> {
   }
 }
 
-class CircleIconButton extends StatelessWidget {
+class MenuButton extends StatelessWidget {
   final IconData icon;
   final VoidCallback onPressed;
   final double size;
   final Color color;
   final Color shadowColor;
 
-  const CircleIconButton({
+  const MenuButton({
     Key? key,
     required this.icon,
     required this.onPressed,
@@ -578,12 +688,11 @@ class CircleIconButton extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
-        shape: BoxShape.circle,
         color: color,
         boxShadow: [
           BoxShadow(
             color: shadowColor.withOpacity(0.7),
-            blurRadius: 8,
+            blurRadius: 4,
             offset: Offset(0, 4),
           ),
         ],

--- a/lib/ui_chat_basic.dart
+++ b/lib/ui_chat_basic.dart
@@ -32,6 +32,8 @@ class _ChatPageState extends State<ChatBasicPage> {
   bool isFirstSend = false; // はじめの問題文の送信をしたか
   bool _isSending = false; // 二度目以降、問題文の送信中を判断
 
+  bool openMenu = false; // メニュー管理
+
   List<String> labels = []; // ラベルの格納用リスト
 
   // テキストのコントローラー
@@ -96,8 +98,7 @@ class _ChatPageState extends State<ChatBasicPage> {
     try {
       final response = await AI.sendMessage(
           Content.text(userMessage)); // AIにメッセージを送信
-      String aiMessage = response.text ?? 'イオからのメッセージが取得できませんでした'; // AIの返答を取得
-
+      String aiMessage = (response.text ?? 'イオからのメッセージが取得できませんでした').trim(); // AIの返答を取得
       setState(() {
         chats.add(chat(1, aiMessage)); // AIの返答を会話リストに追加
         _isSending = false;
@@ -151,7 +152,7 @@ class _ChatPageState extends State<ChatBasicPage> {
           // アバター表示
           Positioned(
             top: MediaQuery.of(context).size.height * 0.18,
-            left: MediaQuery.of(context).size.width * -0.1,
+            left: MediaQuery.of(context).size.width * -0.05,
             child: SizedBox(
               height: MediaQuery.of(context).size.height * 0.26,
               width: MediaQuery.of(context).size.width * 0.7,
@@ -184,31 +185,42 @@ class _ChatPageState extends State<ChatBasicPage> {
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
                     ),
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: AppColors.white, width: 2),
+                    borderRadius: BorderRadius.circular(40),
+                    border: Border.all(color: AppColors.background, width: 3),
                   ),
                   child: Text('イオ', style: TextStyle(
-                    color: AppColors.white,
-                    shadows: [
-                      Shadow(
-                        blurRadius: 20,
-                        color: AppColors.black,
-                        offset: Offset(0, 0),
-                      ),
-                    ],
+                    color: AppColors.black,
                     fontSize: 20,
                     fontWeight: FontWeight.bold,),)
+              )
+          ),
+
+          // メニュー⇆チャット切替ボタン
+          Positioned(
+              top: MediaQuery.of(context).size.height * 0.15,
+              right: MediaQuery.of(context).size.width * 0.15,
+              child:
+              MenuButton(
+                icon: openMenu ? Icons.chat : Icons.menu,
+                onPressed: () {
+                  setState(() {
+                    openMenu = !openMenu;
+                  });
+                },
               )
           ),
 
           // 会話部分
           Column(
             children: [
-              SizedBox(height: MediaQuery.of(context).size.height * 0.05,),
+              SizedBox(
+                height: MediaQuery.of(context).size.height * 0.05,
+                width: MediaQuery.of(context).size.width,
+              ),
 
               // 問題文を表示するボタン
               Container(
-                width: MediaQuery.of(context).size.width * 0.95,
+                width: MediaQuery.of(context).size.width * 0.9,
                 height: MediaQuery.of(context).size.height * 0.1,
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
@@ -217,7 +229,7 @@ class _ChatPageState extends State<ChatBasicPage> {
                     end: Alignment.bottomRight,
                   ),
                   borderRadius: BorderRadius.circular(40),
-                  border: Border.all(color: AppColors.white, width: 4),
+                  border: Border.all(color: AppColors.background, width: 3),
                   boxShadow: [
                     BoxShadow(
                       color: AppColors.mainColor.withOpacity(0.7),
@@ -245,10 +257,10 @@ class _ChatPageState extends State<ChatBasicPage> {
                                 end: Alignment.bottomRight,
                               ),
                               borderRadius: BorderRadius.circular(12),
-                              border: Border.all(color: AppColors.white, width: 4),
+                              border: Border.all(color: AppColors.background, width: 4),
                             ),
                             child: Padding(
-                              padding: const EdgeInsets.all(16.0),
+                              padding: const EdgeInsets.all(8),
                               child: Column(
                                 mainAxisSize: MainAxisSize.max,
                                 children: [
@@ -286,24 +298,17 @@ class _ChatPageState extends State<ChatBasicPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(50),
                     ),
-                    padding: EdgeInsets.symmetric(horizontal: 48, vertical: 24),
+                    padding: EdgeInsets.symmetric(vertical: 12, horizontal: 24),
                   ),
                   child: Text(
                     inputText,
                     style: TextStyle(
-                      color: AppColors.white,
-                      shadows: [
-                        Shadow(
-                          blurRadius: 20,
-                          color: AppColors.black,
-                          offset: Offset(0, 0),
-                        ),
-                      ],
+                      color: AppColors.black,
                       fontSize: MediaQuery.of(context).size.width * 0.05,
                       fontWeight: FontWeight.bold,
                     ),
                     overflow: TextOverflow.ellipsis,
-                    maxLines: 1,
+                    maxLines: 2,
                   ),
                 ),
               ),
@@ -311,6 +316,7 @@ class _ChatPageState extends State<ChatBasicPage> {
               SizedBox(height: MediaQuery.of(context).size.height * 0.22),
 
               // チャット部分
+              if (!openMenu)
               Expanded(
                 child: ListView.builder(
                   reverse: true,
@@ -335,15 +341,16 @@ class _ChatPageState extends State<ChatBasicPage> {
                                 ),
                                 child: IntrinsicWidth(
                                   child: Container(
-                                    padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                                    padding: EdgeInsets.symmetric(vertical: 8, horizontal: 24),
                                     margin: EdgeInsets.only(bottom: 8, left: chat.p == 0 ? 40 : 8, right: chat.p == 0 ? 8 : 40),
+                                    constraints: BoxConstraints(minWidth: 80),
                                     decoration: BoxDecoration(
                                       gradient: LinearGradient(
                                         colors: [chat.p == 0 ? AppColors.mainColor : AppColors.subColor, chat.p == 0 ? AppColors.mainColor : AppColors.white],
                                         begin: Alignment.topLeft,
                                         end: Alignment.bottomRight,
                                       ),
-                                      borderRadius: BorderRadius.circular(12),
+                                      borderRadius: BorderRadius.circular(24),
                                     ),
                                     child: Text(
                                       chat.str,
@@ -370,7 +377,147 @@ class _ChatPageState extends State<ChatBasicPage> {
                 ),
               ),
 
+              // メニュー部分
+              if (openMenu)
+                Expanded(
+                    child: Column(
+                      children: [
+                        SizedBox(height: MediaQuery.of(context).size.height * 0.1,),
+
+                        // ヘルプボタン
+                        Container(
+                          width: MediaQuery.of(context).size.width * 0.8,
+                          height: MediaQuery.of(context).size.height * 0.05,
+                          decoration: BoxDecoration(
+                            color: AppColors.mainColor,
+                            borderRadius: BorderRadius.circular(24),
+                            border: Border.all(color: AppColors.background, width: 3),
+                            boxShadow: [
+                              BoxShadow(
+                                color: AppColors.mainColor.withOpacity(0.7),
+                                offset: Offset(0, 4),
+                                blurRadius: 10,
+                              ),
+                            ],
+                          ),
+                          child: ElevatedButton(
+                            onPressed: () {},
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.transparent,
+                              shadowColor: Colors.transparent,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                            ),
+                            child: Text(
+                              'チャット画面の使い方',
+                              style: TextStyle(
+                                color: AppColors.white,
+                                fontSize: MediaQuery.of(context).size.width * 0.05,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+
+                        SizedBox(height: MediaQuery.of(context).size.height * 0.05,),
+
+                        // ホームに戻るボタン
+                        Container(
+                          width: MediaQuery.of(context).size.width * 0.8,
+                          height: MediaQuery.of(context).size.height * 0.05,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [AppColors.subColor, AppColors.white],
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                            ),
+                            borderRadius: BorderRadius.circular(24),
+                            border: Border.all(color: AppColors.background, width: 3),
+                            boxShadow: [
+                              BoxShadow(
+                                color: AppColors.mainColor.withOpacity(0.7),
+                                offset: Offset(0, 4),
+                                blurRadius: 10,
+                              ),
+                            ],
+                          ),
+                          child: ElevatedButton(
+                            onPressed: () {Navigator.pushNamed(context, '/home');},
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.transparent,
+                              shadowColor: Colors.transparent,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                            ),
+                            child: Text(
+                              'ホームに戻る',
+                              style: TextStyle(
+                                color: AppColors.black,
+                                fontSize: MediaQuery.of(context).size.width * 0.05,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+
+                        SizedBox(height: MediaQuery.of(context).size.height * 0.05,),
+
+                        // 今の問題をやり直すボタン
+                        Container(
+                          width: MediaQuery.of(context).size.width * 0.8,
+                          height: MediaQuery.of(context).size.height * 0.05,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [AppColors.subColor, AppColors.white],
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                            ),
+                            borderRadius: BorderRadius.circular(24),
+                            border: Border.all(color: AppColors.background, width: 3),
+                            boxShadow: [
+                              BoxShadow(
+                                color: AppColors.mainColor.withOpacity(0.7),
+                                offset: Offset(0, 4),
+                                blurRadius: 10,
+                              ),
+                            ],
+                          ),
+                          child: ElevatedButton(
+                            onPressed: () {
+                              setState(() {
+                                chats.clear();
+                                chats.add(chat(0, inputText));
+                                openMenu = false;
+                              });
+                              AI.sendMessage(Content.text('もう一度始めから教えて！'));
+                              _getAIResponse(inputText);
+
+                            },
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.transparent,
+                              shadowColor: Colors.transparent,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                            ),
+                            child: Text(
+                              '始めからやり直す',
+                              style: TextStyle(
+                                color: AppColors.black,
+                                fontSize: MediaQuery.of(context).size.width * 0.05,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    )
+                ),
+
               // 入力部分
+              if (!openMenu)
               Padding(
                 padding: const EdgeInsets.all(20),
                 child: Row(
@@ -383,11 +530,18 @@ class _ChatPageState extends State<ChatBasicPage> {
                         decoration: InputDecoration(
                           hintText: _isSending ? "イオの応答を待っています..." : "メッセージを入力...",
                           hintStyle: TextStyle(color: AppColors.mainColor),
-                          border: OutlineInputBorder(
+                          enabledBorder: OutlineInputBorder( // 未フォーカス時
                             borderRadius: BorderRadius.circular(12),
                             borderSide: BorderSide(
-                              color: AppColors.mainColor,
-                              width: 2, // 枠線の太さ
+                              color: _isSending ? AppColors.background : AppColors.mainColor,
+                              width: 3,
+                            ),
+                          ),
+                          focusedBorder: OutlineInputBorder( // フォーカス時
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide(
+                              color: _isSending ? AppColors.background : AppColors.mainColor,
+                              width: 4,
                             ),
                           ),
                         ),
@@ -396,7 +550,7 @@ class _ChatPageState extends State<ChatBasicPage> {
                     SizedBox(width: 8),
                     FloatingActionButton(
                       onPressed: _isSending ? null : _sendMessage,
-                      child: Icon(Icons.send, color: AppColors.white),
+                      child: Icon(Icons.send, color: _isSending ? AppColors.black : AppColors.background),
                       backgroundColor: _isSending ? AppColors.background : AppColors.mainColor,
                     ),
                   ],
@@ -407,119 +561,102 @@ class _ChatPageState extends State<ChatBasicPage> {
             ],
           ),
 
-          // ボタングループ
+          // チャット終了ボタン
           Positioned(
-            top: MediaQuery.of(context).size.height * 0.2,
+            top: MediaQuery.of(context).size.height * 0.32,
             left: MediaQuery.of(context).size.width * 0.5,
-            child: Container(
-                width: MediaQuery.of(context).size.width * 0.4,
-                child: Column(
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        // ホームボタン
-                        CircleIconButton(
-                          icon: Icons.home,
-                          onPressed: () {
-                            Navigator.pushNamed(context, '/home');
-                          },
-                        ),
+            child:
+            Container(
+              width: MediaQuery.of(context).size.width * 0.4,
+              height: MediaQuery.of(context).size.height * 0.06,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [AppColors.accentColor, AppColors.white],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+                borderRadius: BorderRadius.circular(40),
+                border: Border.all(color: AppColors.background, width: 3),
+                boxShadow: [
+                  BoxShadow(
+                    color: AppColors.accentColor.withOpacity(0.7),
+                    offset: Offset(0, 4),
+                    blurRadius: 10,
+                  ),
+                ],
+              ),
+              child: ElevatedButton(
+                onPressed: () async { //フィードバックへ遷移
+                  try {
+                    final feedback = await AI.sendMessage(Content.text(//簡単なフィードバック
+                        '今回の会話はどうだった？私が苦手なところとか分かったら短く(50文字程度)一文で教えてほしいな．'));
+                    final feedbackMessage = feedback.text ??
+                        'フィードバックの作成に失敗しました';
 
-                        SizedBox(height: MediaQuery.of(context).size.width * 0.1),
+                    //詳細のフィードバックを作成
+                    final info = await AI.sendMessage(Content.text('''
+                          今回の会話について，
+                          1,どういう解き方を最初したのか
+                          2,ユーザーが間違えてた部分
+                          3,間違えた部分の正しい解き方
+                          4,問題自体の正しい解き方
+                          を，必ず以下のフォーマットで送ってください
+                          &&内容1&&内容2&&内容3&&内容4
+                          '''));
+                    String infotext = info.text ?? '作成失敗';
+                    final B = infotext.substring(infotext.indexOf('&&')).split('&&');
+                    String firstans = B[1];     //どういう解き方を最初したのか
+                    String wrong = B[2];        //間違えてた部分
+                    String wrongpartans = B[3]; //間違えてた部分の正しい解き方
+                    String correctans = B[4];   //それの正しい解き方
+                    // print("sdoifsdjffd");
+                    // print(firstans);
+                    // print(wrong);
+                    // print(wrongpartans);
+                    // print(correctans);
 
-                        // やり直しボタン
-                        CircleIconButton(
-                          icon: Icons.change_circle_outlined,
-                          onPressed: () {
-                            setState(() {
-                              chats.clear();
-                              chats.add(chat(0, inputText));
-                            });
-                            AI.sendMessage(Content.text('もう一度始めから教えて！'));
-                            _getAIResponse(inputText);
-                          },
-                        ),
-                      ],
-                    ),
+                    Navigator.pushNamed(
+                      context, '/result',
+                      arguments: {
+                        'inputText': inputText,
+                        'feedbackText': feedbackMessage,
+                        'labels': labels,
+                        'firstans': firstans,
+                        'wrong': wrong,
+                        'wrongpartans': wrongpartans,
+                        'correctans': correctans,
+                      },
+                    );
+                  } catch (e) {
+                    Navigator.pushNamed(
+                      context, '/result',
+                      arguments: {
+                        'inputText': inputText,
+                        'feedbackText': 'フィードバックの作成に失敗しました',
+                        'labels': labels,
+                      },
+                    );
+                  }
 
-                    SizedBox(height: MediaQuery.of(context).size.height * 0.02),
-
-                    // チャット終了ボタン
-                    Container(
-                      width: MediaQuery.of(context).size.width * 0.4,
-                      height: MediaQuery.of(context).size.height * 0.06,
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: [AppColors.accentColor, AppColors.white],
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
-                        ),
-                        borderRadius: BorderRadius.circular(40),
-                        border: Border.all(color: AppColors.white, width: 4),
-                        boxShadow: [
-                          BoxShadow(
-                            color: AppColors.accentColor.withOpacity(0.7),
-                            offset: Offset(0, 4),
-                            blurRadius: 10,
-                          ),
-                        ],
-                      ),
-                      child: ElevatedButton(
-                        onPressed: () async { //フィードバックへ遷移
-                          try {
-                            final feedback = await AI.sendMessage(Content.text(
-                                '今回の会話はどうだった？私が苦手なところとか分かったら短く一文で教えてほしいな。またね！'));
-                            final feedbackMessage = feedback.text ??
-                                'フィードバックの作成に失敗しました';
-                            Navigator.pushNamed(
-                              context, '/result',
-                              arguments: {
-                                'inputText': inputText,
-                                'feedbackText': feedbackMessage,
-                                'labels': labels,
-                              },
-                            );
-                          } catch (e) {
-                            Navigator.pushNamed(
-                              context, '/result',
-                              arguments: {
-                                'inputText': inputText,
-                                'feedbackText': 'フィードバックの作成に失敗しました',
-                                'labels': labels,
-                              },
-                            );
-                          }
-
-                        },
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.transparent,
-                          shadowColor: Colors.transparent,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(30),
-                          ),
-                        ),
-                        child: Text(
-                          '解けた！',
-                          style: TextStyle(
-                            color: AppColors.white,
-                            shadows: [
-                              Shadow(
-                                blurRadius: 20,
-                                color: AppColors.black,
-                                offset: Offset(0, 0),
-                              ),
-                            ],
-                            fontSize: MediaQuery.of(context).size.width * 0.05,
-                            fontWeight: FontWeight.bold,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                          maxLines: 1,
-                        ),
-                      ),
-                    ),
-                  ],
-                )
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.transparent,
+                  shadowColor: Colors.transparent,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+                child: Text(
+                  'できた！',
+                  style: TextStyle(
+                    color: AppColors.black,
+                    fontSize: MediaQuery.of(context).size.width * 0.05,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
             ),
           ),
 
@@ -529,14 +666,14 @@ class _ChatPageState extends State<ChatBasicPage> {
   }
 }
 
-class CircleIconButton extends StatelessWidget {
+class MenuButton extends StatelessWidget {
   final IconData icon;
   final VoidCallback onPressed;
   final double size;
   final Color color;
   final Color shadowColor;
 
-  const CircleIconButton({
+  const MenuButton({
     Key? key,
     required this.icon,
     required this.onPressed,
@@ -551,12 +688,11 @@ class CircleIconButton extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
-        shape: BoxShape.circle,
         color: color,
         boxShadow: [
           BoxShadow(
             color: shadowColor.withOpacity(0.7),
-            blurRadius: 8,
+            blurRadius: 4,
             offset: Offset(0, 4),
           ),
         ],


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #109

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- Advanced用の色調整
- AIからの返答の最後の空行をカット
- ホームに戻るボタン、やり直すボタンを削除
- メニュー⇆チャット切り替えボタンを作成し、メニュー表示において、「チャット画面の使い方」「ホームに戻る」「始めからやり直す」ボタンを作成
- その他既存UIの調整

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- 使い方は未実装