### PR TITLE
[add] #171 ヘルプダイアログのdartファイル化

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'terms_content.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:image_editor_plus/image_editor_plus.dart';
+import 'widget_help_dialog.dart';
 
 bool _isBasicMode = false;
 
@@ -545,7 +546,10 @@ class _MyHomePageState extends State<MyHomePage> {
                         ),
 
                         // ヘルプを表示するボタン
-                        HelpButton(mode: _isBasicMode ? 'basic' : 'advanced'),
+                        HelpButton(
+                          mode: _isBasicMode ? 'basic' : 'advanced',
+                          content: 'home',
+                        ),
                       ]
                   )
               ),
@@ -812,8 +816,9 @@ class _ModeSelectDialogState extends State<ModeSelectDialog> {
 // ヘルプを表示するボタン
 class HelpButton extends StatelessWidget {
   final String mode; // モード: 'basic' or 'advanced'
+  final String content; // 内容: 'home'
 
-  const HelpButton({Key? key, required this.mode}) : super(key: key);
+  const HelpButton({Key? key, required this.mode, required this.content}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -866,203 +871,9 @@ class HelpButton extends StatelessWidget {
     showDialog(
       context: context,
       builder: (context) {
-        return HelpDialog(mode: mode);
+        return HelpDialog(mode: mode, content: content,);
       },
     );
-  }
-}
-class HelpDialog extends StatefulWidget {
-  final String mode;
-
-  const HelpDialog({Key? key, required this.mode}) : super(key: key);
-
-  @override
-  _HelpDialogState createState() => _HelpDialogState();
-}
-class _HelpDialogState extends State<HelpDialog> {
-  PageController _pageController = PageController();
-  int _currentPage = 0;
-
-  // ヘルプ内容
-  late final List<Map<String, String>> helpPages;
-  @override
-  void initState() {
-    super.initState();
-
-    if (widget.mode == 'basic') {
-      helpPages = [
-        // ベーシック用
-        {"image": "assets/help0.png", "head": "はじめに", "text": "『START』ボタンをおして、もんだいをはじめよう！\nこのアプリのつかいかたがわからなくなったら、いつでもこのヘルプをみてね！"},
-        {"image": "assets/help1.png", "head": "もんだいの いれかた", "text": "もんだいを いれるほうほうは、こえ・しゃしん・もじ の３つ！\nさっそくいれてみようか！"},
-        {"image": "assets/help2.png", "head": "もんだいを なおそう！", "text": "こえ・しゃしんでいれたもんだいが まちがっていたら、なおすことができるよ。"},
-        {"image": "assets/help3.png", "head": "もんだいの ぶんるい", "text": "\nもんだいにあう『かもく』を えらんでね！\nまちがっていても だいじょうぶ。\nえらびなおすことができるよ。"},
-        {"image": "assets/help4.png", "head": "AIと おしゃべりしながら といてみよう！", "text": "もんだいが できたら、AIが おてつだいしてくれるよ。\nこたえがわかったら『とけた！』ボタンを おしてね。\nみぎうえにあるおうちのボタンからいちばんさいしょのページにもどることができるよ。\nそれと、やじるしのマークをおすともういちどさいしょからAIがおてつだいしてくれるよ。"},
-        {"image": "assets/help5.png", "head": "どんなことにつかうのか　つぎのもんだい", "text": "とけたら、これからこのちしきをどうやってつかうのかをAIがおしえてくれるよ！\nにている もんだいにも チャレンジしてみてね！"},
-      ];
-    } else {
-      helpPages = [
-        // アドバンス用
-        {"image": "assets/help0.png", "head": "まずは、STARTボタンを押して問題を送信しよう！", "text": "ここでは、このアプリの使用方法を確認することができます。\n右下のボタンからは、利用規約、ライセンス表示を確認することができます。"},
-        {"image": "assets/help1.png", "head": "問題の送信方法を選んで、問題を送信しよう！", "text": "送信方法は、音声入力、画像入力(画像ファイルからor写真を撮影)、テキスト入力から選べます。\n音声や画像を送信した場合は、自動でテキストに変換されます。"},
-        {"image": "assets/help2.png", "head": "問題文の編集をしよう！", "text": "テキスト入力の場合はここで入力、音声や画像で入力した場合は、問題文を修正できます。"},
-        {"image": "assets/help3.png", "head": "問題のラベル(教科・単元)の編集をしよう！", "text": "\n送信された問題文を元に、自動でいくつかのラベルが選択されます。問題にあったラベルを編集・追加してください。\n最大4つのラベルを選択することができます。"},
-        {"image": "assets/help4.png", "head": "AIとのチャットを開始！\nAIの質問に答えながら、問題を解いていこう！", "text": "下のテキストボックスからAIへメッセージを送信すると、AIから返事が返ってきます。\n問題が解けたら、「解けた！」ボタンでチャットが終了できます。\nまた、右上のボタンからは、ホーム画面に戻ることや、今の問題をもう一度初めからやり直すことができます。"},
-        {"image": "assets/help5.png", "head": "チャットを終えると、AIからのフィードバックと類題が表示されるよ！\nフィードバックを参考にして、類題から次の問題を始めてみよう！", "text": "類題を選択することで、新たにAIとのチャットを開始できます。"},
-      ];
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      insetPadding: EdgeInsets.all(MediaQuery.of(context).size.width * 0.04),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-                widget.mode == 'basic'
-                    ? "つかいかた"
-                    : "使い方",
-                style: TextStyle(
-                    color: _isBasicMode
-                        ? B_Colors.black
-                        : A_Colors.black,
-                    fontSize: widget.mode == 'basic'
-                        ? MediaQuery.of(context).size.width * 0.07
-                        : MediaQuery.of(context).size.width * 0.06,
-                    fontWeight: FontWeight.bold)
-            ),
-
-            SizedBox(height: MediaQuery.of(context).size.height * 0.03),
-
-
-            Container(
-              height: MediaQuery.of(context).size.height * 0.5,
-              child: PageView.builder(
-                controller: _pageController,
-                itemCount: helpPages.length,
-                physics: AlwaysScrollableScrollPhysics(),
-                onPageChanged: (index) {
-                  setState(() {
-                    _currentPage = index;
-                  });
-                },
-                itemBuilder: (context, index) {
-                  return SingleChildScrollView( // スクロールを可能にする
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Center(
-                            child: Image.asset(
-                              helpPages[index]['image']!,
-                              height: MediaQuery.of(context).size.height * 0.3,
-                              fit: BoxFit.contain,
-                            ),
-                          ),
-
-                          SizedBox(height: MediaQuery.of(context).size.height * 0.03),
-
-                          Text(
-                            helpPages[index]['head'].toString(),
-                            textAlign: TextAlign.left,
-                            style: TextStyle(
-                                color: _isBasicMode
-                                    ? B_Colors.black
-                                    : A_Colors.black,
-                                fontSize: widget.mode == 'basic'
-                                    ? MediaQuery.of(context).size.width * 0.06
-                                    : MediaQuery.of(context).size.width * 0.05,
-                                fontWeight: FontWeight.bold),
-                          ),
-
-                          SizedBox(height: MediaQuery.of(context).size.height * 0.02),
-
-                          Text(
-                            helpPages[index]['text'].toString(),
-                            textAlign: TextAlign.left,
-                            style: TextStyle(
-                                color: _isBasicMode
-                                    ? B_Colors.black
-                                    : A_Colors.black,
-                              fontSize: widget.mode == 'basic'
-                                  ? MediaQuery.of(context).size.width * 0.05
-                                  : MediaQuery.of(context).size.width * 0.04,
-                            ),
-                          ),
-
-                          SizedBox(height: MediaQuery.of(context).size.height * 0.05),
-                        ],
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-
-            SizedBox(height: 16),
-
-            // インジケーター（現在のページを示すドット）
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: List.generate(helpPages.length, (index) {
-                return Container(
-                  margin: EdgeInsets.symmetric(horizontal: 4),
-                  width: 10,
-                  height: 10,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: _currentPage == index ? A_Colors.subColor : _isBasicMode ? B_Colors.black : A_Colors.black,
-                  ),
-                );
-              }),
-            ),
-
-            SizedBox(height: 16),
-
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                TextButton(
-                  onPressed: _currentPage > 0
-                      ? () {
-                    _pageController.previousPage(
-                      duration: Duration(milliseconds: 300),
-                      curve: Curves.easeInOut,
-                    );
-                  }
-                      : null,
-                  child: Text(widget.mode == 'basic' ? "←もどる" : "←戻る", style: TextStyle(color: _isBasicMode ? B_Colors.black : A_Colors.black, fontSize: 18)),
-                ),
-                TextButton(
-                  onPressed: _currentPage < helpPages.length - 1
-                      ? () {
-                    _pageController.nextPage(
-                      duration: Duration(milliseconds: 300),
-                      curve: Curves.easeInOut,
-                    );
-                  }
-                      : () {
-                    Navigator.pop(context); // 最後のページならダイアログを閉じる
-                  },
-                  child: Text(_currentPage < helpPages.length - 1 ? widget.mode == 'basic' ? "→つぎ" : "→次へ": widget.mode == 'basic' ? "とじる" : "閉じる", style: TextStyle(color: _isBasicMode ? B_Colors.black : A_Colors.black, fontSize: 18)),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  @override
-  void dispose() {
-    _pageController.dispose();
-    super.dispose();
   }
 }
 

--- a/lib/widget_help_dialog.dart
+++ b/lib/widget_help_dialog.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'colors.dart';
+
+class HelpDialog extends StatefulWidget {
+  final String mode; // モード: 'basic' or 'advanced'
+  final String content; // 内容: 'home','chat'
+
+  const HelpDialog({Key? key, required this.mode, required this.content}) : super(key: key);
+
+  @override
+  _HelpDialogState createState() => _HelpDialogState();
+}
+class _HelpDialogState extends State<HelpDialog> {
+  PageController _pageController = PageController(); // ページコントローラ
+  int _currentPage = 0; // 現在のページ
+
+  // ヘルプ内容
+  late final List<Map<String, String>> helpPages;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // ヘルプ文章
+    if (widget.content == 'home') {
+      if (widget.mode == 'basic') {
+        helpPages = [
+          // ベーシック用
+          {"image": "assets/help0.png", "head": "はじめに", "text": "『START』ボタンをおして、もんだいをはじめよう！\nこのアプリのつかいかたがわからなくなったら、いつでもこのヘルプをみてね！"},
+          {"image": "assets/help1.png", "head": "もんだいの いれかた", "text": "もんだいを いれるほうほうは、こえ・しゃしん・もじ の３つ！\nさっそくいれてみようか！"},
+          {"image": "assets/help2.png", "head": "もんだいを なおそう！", "text": "こえ・しゃしんでいれたもんだいが まちがっていたら、なおすことができるよ。"},
+          {"image": "assets/help3.png", "head": "もんだいの ぶんるい", "text": "\nもんだいにあう『かもく』を えらんでね！\nまちがっていても だいじょうぶ。\nえらびなおすことができるよ。"},
+          {"image": "assets/help4.png", "head": "AIと おしゃべりしながら といてみよう！", "text": "もんだいが できたら、AIが おてつだいしてくれるよ。\nこたえがわかったら『とけた！』ボタンを おしてね。\nみぎうえにあるおうちのボタンからいちばんさいしょのページにもどることができるよ。\nそれと、やじるしのマークをおすともういちどさいしょからAIがおてつだいしてくれるよ。"},
+          {"image": "assets/help5.png", "head": "どんなことにつかうのか　つぎのもんだい", "text": "とけたら、これからこのちしきをどうやってつかうのかをAIがおしえてくれるよ！\nにている もんだいにも チャレンジしてみてね！"},
+        ];
+      } else {
+        helpPages = [
+          // アドバンス用
+          {"image": "assets/help0.png", "head": "まずは、STARTボタンを押して問題を送信しよう！", "text": "ここでは、このアプリの使用方法を確認することができます。\n右下のボタンからは、利用規約、ライセンス表示を確認することができます。"},
+          {"image": "assets/help1.png", "head": "問題の送信方法を選んで、問題を送信しよう！", "text": "送信方法は、音声入力、画像入力(画像ファイルからor写真を撮影)、テキスト入力から選べます。\n音声や画像を送信した場合は、自動でテキストに変換されます。"},
+          {"image": "assets/help2.png", "head": "問題文の編集をしよう！", "text": "テキスト入力の場合はここで入力、音声や画像で入力した場合は、問題文を修正できます。"},
+          {"image": "assets/help3.png", "head": "問題のラベル(教科・単元)の編集をしよう！", "text": "\n送信された問題文を元に、自動でいくつかのラベルが選択されます。問題にあったラベルを編集・追加してください。\n最大4つのラベルを選択することができます。"},
+          {"image": "assets/help4.png", "head": "AIとのチャットを開始！\nAIの質問に答えながら、問題を解いていこう！", "text": "下のテキストボックスからAIへメッセージを送信すると、AIから返事が返ってきます。\n問題が解けたら、「解けた！」ボタンでチャットが終了できます。\nまた、右上のボタンからは、ホーム画面に戻ることや、今の問題をもう一度初めからやり直すことができます。"},
+          {"image": "assets/help5.png", "head": "チャットを終えると、AIからのフィードバックと類題が表示されるよ！\nフィードバックを参考にして、類題から次の問題を始めてみよう！", "text": "類題を選択することで、新たにAIとのチャットを開始できます。"},
+        ];
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: EdgeInsets.all(MediaQuery.of(context).size.width * 0.04),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // タイトル
+            Text(
+                widget.mode == 'basic'
+                    ? "つかいかた"
+                    : "使い方",
+                style: TextStyle(
+                    color:  widget.mode == 'basic'
+                        ? B_Colors.black
+                        : A_Colors.black,
+                    fontSize: widget.mode == 'basic'
+                        ? MediaQuery.of(context).size.width * 0.07
+                        : MediaQuery.of(context).size.width * 0.06,
+                    fontWeight: FontWeight.bold)
+            ),
+
+            SizedBox(height: MediaQuery.of(context).size.height * 0.03),
+
+            // 画像＋文章
+            Container(
+              height: MediaQuery.of(context).size.height * 0.5,
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: helpPages.length,
+                physics: AlwaysScrollableScrollPhysics(),
+                onPageChanged: (index) {
+                  setState(() {
+                    _currentPage = index;
+                  });
+                },
+                itemBuilder: (context, index) {
+                  return SingleChildScrollView( // スクロールを可能にする
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Center(
+                            child: Image.asset(
+                              helpPages[index]['image']!,
+                              height: MediaQuery.of(context).size.height * 0.3,
+                              fit: BoxFit.contain,
+                            ),
+                          ),
+
+                          SizedBox(height: MediaQuery.of(context).size.height * 0.03),
+
+                          // ページタイトル
+                          Text(
+                            helpPages[index]['head'].toString(),
+                            textAlign: TextAlign.left,
+                            style: TextStyle(
+                                color:  widget.mode == 'basic'
+                                    ? B_Colors.black
+                                    : A_Colors.black,
+                                fontSize: widget.mode == 'basic'
+                                    ? MediaQuery.of(context).size.width * 0.06
+                                    : MediaQuery.of(context).size.width * 0.05,
+                                fontWeight: FontWeight.bold),
+                          ),
+
+                          SizedBox(height: MediaQuery.of(context).size.height * 0.02),
+
+                          // ヘルプ本文
+                          Text(
+                            helpPages[index]['text'].toString(),
+                            textAlign: TextAlign.left,
+                            style: TextStyle(
+                              color:  widget.mode == 'basic'
+                                  ? B_Colors.black
+                                  : A_Colors.black,
+                              fontSize: widget.mode == 'basic'
+                                  ? MediaQuery.of(context).size.width * 0.05
+                                  : MediaQuery.of(context).size.width * 0.04,
+                            ),
+                          ),
+
+                          SizedBox(height: MediaQuery.of(context).size.height * 0.05),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+
+            SizedBox(height: 16),
+
+            // インジケーター（現在のページを示すドット）
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(helpPages.length, (index) {
+                return Container(
+                  margin: EdgeInsets.symmetric(horizontal: 4),
+                  width: 10,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _currentPage == index
+                        ? A_Colors.subColor
+                        :  widget.mode == 'basic'
+                        ? B_Colors.black
+                        : A_Colors.black,
+                  ),
+                );
+              }),
+            ),
+
+            SizedBox(height: 16),
+
+            // ページ移動UI
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                TextButton(
+                  onPressed: _currentPage > 0
+                      ? () {
+                    _pageController.previousPage(
+                      duration: Duration(milliseconds: 300),
+                      curve: Curves.easeInOut,
+                    );
+                  }
+                      : null,
+                  child: Text(
+                      widget.mode == 'basic'
+                          ? "←もどる"
+                          : "←戻る",
+                      style: TextStyle(
+                          color:  widget.mode == 'basic'
+                              ? B_Colors.black
+                              : A_Colors.black,
+                          fontSize: 18
+                      ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: _currentPage < helpPages.length - 1
+                      ? () {
+                    _pageController.nextPage(
+                      duration: Duration(milliseconds: 300),
+                      curve: Curves.easeInOut,
+                    );
+                  }
+                      : () {
+                    Navigator.pop(context); // 最後のページならダイアログを閉じる
+                  },
+                  child: Text(
+                      _currentPage < helpPages.length - 1
+                          ? widget.mode == 'basic'
+                            ? "→つぎ"
+                            : "→次へ"
+                          : widget.mode == 'basic'
+                            ? "とじる"
+                            : "閉じる",
+                      style: TextStyle(
+                          color:  widget.mode == 'basic'
+                              ? B_Colors.black
+                              : A_Colors.black,
+                          fontSize: 18
+                      ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #171

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- ヘルプダイアログをwidget_help_dialog.dartとして、mainから分離
- 新しくcontentを引数として追加し、参照時に内容を指定できるよう変更

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- 分離したのはダイアログのみ。ダイアログを開くボタンは各ページで記述