### PR TITLE
[fix] fb一覧が1つしか出ないのを修正

### DIFF
--- a/lib/ui_fblist.dart
+++ b/lib/ui_fblist.dart
@@ -104,19 +104,17 @@ class _FblistPageState extends State<FblistPage> {
       for (int i = 0; i < records.length; i++) { 
         List<String> subjects = records[i]['subject'].split('&&'); // subject取り出し
         List<String> fields = records[i]['subject'].split('&&');  // field取り出し
-        List<List<String>> allLabels = [];  // labelのリスト
         // ラベルの生成
         List<String> tmpLabel = [];
         int labelLength = subjects.length < fields.length ? subjects.length : fields.length;
         for (int j = 0; j < labelLength; j++) {
           tmpLabel.add('${subjects[j]} - ${fields[j]}');
         }
-        allLabels.add(tmpLabel);  //labels保存
         fblist.add(feedback(
           records[i]['id'],
           subjects,
           fields,
-          allLabels[i],
+          tmpLabel,
           records[i]['problem'],
           records[i]['summary'],
           records[i]['wrong'],


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #170 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- SQLから読み取る際、ラベルの指定ミスがあったのを修正

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x
