### PR TITLE
[fix]#275basicモードの全体統計が修正されない問題の修正3,グラフの色修正

### DIFF
--- a/lib/ui_statistics.dart
+++ b/lib/ui_statistics.dart
@@ -669,4 +669,10 @@ const Map<String, Color> kSubjectColor = {
   '英語'       : Subject_Colors.english,
   '情報'       : Subject_Colors.information,
   'その他'     : Subject_Colors.other,
+  'こくご'     : Subject_Colors.japanese,
+  'さんすう'    : Subject_Colors.math,
+  'りか'       : Subject_Colors.science,
+  'しゃかい'    : Subject_Colors.socialstudies,
+  'えいご'      : Subject_Colors.english,
+
 };


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #275 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- basicモードでもグラフがひょうじされるようになった
- グラフの色を教科と合わせる

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x
